### PR TITLE
added audit logging for db to backend

### DIFF
--- a/backend/masz/data/DataContext.cs
+++ b/backend/masz/data/DataContext.cs
@@ -2,12 +2,19 @@ using System;
 using masz.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace masz.data
 {
     public class DataContext : DbContext
     {
         public DataContext(DbContextOptions<DataContext> options) : base(options) { }
+
+        //static LoggerFactory object
+        public static readonly ILoggerFactory loggerFactory = LoggerFactory.Create(builder => {
+            builder.AddConsole();
+        });
 
         public DbSet<ModCase> ModCases { get; set; }        
         public DbSet<ModCaseComments> ModCaseComments { get; set; }
@@ -26,6 +33,12 @@ namespace masz.data
 
             // FK - configuraiton
             builder.HasOne(u => u.ModCase).WithMany().HasForeignKey(u => u.ModCaseId).IsRequired(true);
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseLoggerFactory(loggerFactory)
+                .EnableSensitiveDataLogging();
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/masz/masz.csproj
+++ b/backend/masz/masz.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.2" />
     <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>

--- a/webinterface/app/package-lock.json
+++ b/webinterface/app/package-lock.json
@@ -5483,7 +5483,7 @@
             "dev": true
         },
         "node-forge": {
-            "version": "0.9.0",
+            "version": ">=0.10.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
             "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
             "dev": true
@@ -7336,7 +7336,7 @@
             "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
             "dev": true,
             "requires": {
-                "node-forge": "0.9.0"
+                "node-forge": ">=0.10.0"
             }
         },
         "semver": {


### PR DESCRIPTION
- fixes #62 added audit logging
- fixed dependency vulnerability

```
CVE-2020-7720
high severity
Vulnerable versions: < 0.10.0
Patched version: 0.10.0 
The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function.
Note: Version 0.10.0 is a breaking change removing the vulnerable functions.
```