### PR TITLE
Added say command

### DIFF
--- a/discordbot/src/commands/__init__.py
+++ b/discordbot/src/commands/__init__.py
@@ -21,6 +21,6 @@ from .say import say
 from .infrastructure import register_commands, on_command_error
 
 
-ALL_COMMANDS = [ invite, version, features, whois, register, url, mute, kick, ban, warn, report, tempmute, tempban, cases, viewg, view, track, cleanup, help ]
+ALL_COMMANDS = [ invite, version, features, whois, register, url, mute, kick, ban, warn, report, tempmute, tempban, cases, viewg, view, track, cleanup, help, say ]
 
 register_commands(ALL_COMMANDS)

--- a/discordbot/src/commands/__init__.py
+++ b/discordbot/src/commands/__init__.py
@@ -17,6 +17,7 @@ from .view import view
 from .track import track
 from .cleanup import cleanup
 from .help import help
+from .say import say
 from .infrastructure import register_commands, on_command_error
 
 

--- a/discordbot/src/commands/say.py
+++ b/discordbot/src/commands/say.py
@@ -35,24 +35,24 @@ async def _say(ctx, channel: TextChannel = None, *,message):
             try:
                 await ctx.send("Message sent", hidden=True)
             except Exception as e:
-                console.error("confirmation message couldn't be sent. The command may have worked anyway.: {e}")
+                console.critical("confirmation message couldn't be sent. The command may have worked anyway.: {e}")
         else:
             try:
                 await ctx.message.add_reaction("✅")
             except Exception as e:
-                console.error("Failed to add reaction to say command: {e}")
+                console.critical("Failed to add reaction to say command: {e}")
     # and do the same if the message couldn't been sent
     else:
         if slash:
             try:
                 await ctx.send("Message couldn't be sent. Maybe 'Send message'-Permission is not given to this bot for the demanded channel?", hidden=True)
             except Exception as e:
-                console.error("confirmation message couldn't be sent. Sending the required message also failed: {e}")
+                console.critical("confirmation message couldn't be sent. Sending the required message also failed: {e}")
         else:
             try:
                 await ctx.message.add_reaction("❌")
             except Exception as e:
-                console.error("Failed to add reaction to say command: {e}")
+                console.critical("Failed to add reaction to say command: {e}")
 
 
 # register the command for slash commands

--- a/discordbot/src/commands/say.py
+++ b/discordbot/src/commands/say.py
@@ -1,0 +1,59 @@
+from discord import TextChannel
+from discord.ext.commands import Context
+from .infrastructure import record_usage, CommandDefinition, registered_guild_and_admin_or_mod_only
+from discord_slash.utils.manage_commands import create_option, SlashCommandOptionType
+
+async def _say(ctx, channel: TextChannel = None, *,message):
+    await registered_guild_and_admin_or_mod_only(ctx)
+    record_usage(ctx)
+    if message is None:
+        await ctx.send("Please write a message.")
+        return
+    if Channel is None:
+        channel = ctx.channel
+    slash = isinstance(ctx, SlashContext)
+    if slash:
+        try:
+            await ctx.message.add_reaction("👀")
+        except Exception as e:
+            console.error("Failed to add reaction to say command: {e}")
+    try:
+        await channel.send(message)
+        success = True
+    except Exception as f:
+        success = False
+    if success:
+        if slash:
+            try:
+                await ctx.send("Message sent", hidden=True)
+            except Exception as e:
+                console.error("confirmation message couldn't be sent. The command may have worked anyway.: {e}")
+        else:
+            try:
+                await ctx.message.add_reaction("✅")
+            except Exception as e:
+                console.error("Failed to add reaction to say command: {e}")
+    else:
+        if slash:
+            try:
+                await ctx.send("Message couldn't be sent. Maybe 'Send message'-Permission is not given to this bot for the demanded channel?", hidden=True)
+            except Exception as e:
+                console.error("confirmation message couldn't be sent. Sending the required message also failed: {e}")
+        else:
+            try:
+                await ctx.message.add_reaction("❌")
+            except Exception as e:
+                console.error("Failed to add reaction to say command: {e}")
+
+
+
+say = CommandDefinition(
+    func= _say,
+    short_help = "Let the bot send a message",
+    long_help="This command lets the mod write a message. The first Argument is the channel. \n The second Argument is the message you want the bot to send. This can be any message you can write in discord.\n This command requires Admin or Moderator privileges.",
+    usage="say <channel> <message>",
+    options = [
+        create_option("channel","channel to write the message in", SlashCommandOptionType.CHANNEL, True),
+        create_option("message","message content the bott shall write", SlashCommandOptionType.STRING, True)
+    ]
+)

--- a/discordbot/src/commands/say.py
+++ b/discordbot/src/commands/say.py
@@ -23,12 +23,6 @@ async def _say(ctx, channel: TextChannel = None, *,message):
         channel = ctx.channel
     #check whether command is triggered by slash command or message. required for feedback 
     slash = isinstance(ctx, SlashContext)
-    # if triggered by message, add the 👀 reaction to confirm the message is being processed
-    if slash:
-        try:
-            await ctx.message.add_reaction("👀")
-        except Exception as e:
-            console.error("Failed to add reaction to say command: {e}")
     # try to send the message the user wants to. Save whether this was successful
     try:
         await channel.send(message)

--- a/discordbot/src/commands/say.py
+++ b/discordbot/src/commands/say.py
@@ -1,10 +1,12 @@
-# imports
+#third-party imports
 from discord import TextChannel
 from discord.ext.commands import Context
-from .infrastructure import record_usage, CommandDefinition, registered_guild_and_admin_or_mod_only
 from discord_slash import SlashContext
 from discord_slash.utils.manage_commands import create_option, SlashCommandOptionType
+
+# integrated imports
 from helpers import console
+from .infrastructure import record_usage, CommandDefinition, registered_guild_and_admin_or_mod_only
 
 # procedure when the say command is triggered
 async def _say(ctx, channel: TextChannel = None, *,message):


### PR DESCRIPTION
This PR adds a say command which lets the bot send a discord message in a specific channel. This mostly implements #350 , except specifying a channel is required(technical requirement for this implementation). This PR directly implements the say command as slash command.