### PR TITLE
Bumped Scrutor from 3.3.0 to 4.2.0

### DIFF
--- a/backend/MASZ/Commands/AntiraidCommand.cs
+++ b/backend/MASZ/Commands/AntiraidCommand.cs
@@ -3,7 +3,6 @@ using Discord.Interactions;
 using Discord.Net;
 using MASZ.Attributes;
 using MASZ.Enums;
-using System.Net;
 
 namespace MASZ.Commands
 {

--- a/backend/MASZ/Commands/BaseCommand.cs
+++ b/backend/MASZ/Commands/BaseCommand.cs
@@ -32,7 +32,8 @@ namespace MASZ.Commands
             RunCMDSetup().GetAwaiter().GetResult();
         }
 
-        private async Task RunCMDSetup() {
+        private async Task RunCMDSetup()
+        {
             if (Context.Guild != null)
             {
                 await Translator.SetContext(Context.Guild.Id);

--- a/backend/MASZ/Commands/CleanupCommand.cs
+++ b/backend/MASZ/Commands/CleanupCommand.cs
@@ -77,7 +77,7 @@ namespace MASZ.Commands
         {
             ulong lastId = 0;
             int deleted = 0;
-            List<IMessage> toDelete = new ();
+            List<IMessage> toDelete = new();
             var messages = channel.GetMessagesAsync(Math.Min(limit, 100));
 
             if (await messages.CountAsync() < Math.Min(limit, 100))

--- a/backend/MASZ/Commands/SayCommand.cs
+++ b/backend/MASZ/Commands/SayCommand.cs
@@ -34,7 +34,7 @@ namespace MASZ.Commands
                 try
                 {
                     GuildConfig guildConfig = await GuildConfigRepository.CreateDefault(ServiceProvider).GetGuildConfig(Context.Guild.Id);
-                    if (! string.IsNullOrEmpty(guildConfig.ModInternalNotificationWebhook))
+                    if (!string.IsNullOrEmpty(guildConfig.ModInternalNotificationWebhook))
                     {
                         await DiscordAPI.ExecuteWebhook(
                             guildConfig.ModInternalNotificationWebhook,
@@ -47,7 +47,8 @@ namespace MASZ.Commands
                             AllowedMentions.None
                         );
                     }
-                } catch (Exception ex)
+                }
+                catch (Exception ex)
                 {
                     Logger.LogError(ex, $"Something went wrong while sending the internal notification for the say command by {Context.User.Id} in {Context.Guild.Id}/{Context.Channel.Id}.");
                 }

--- a/backend/MASZ/Commands/UnbanCommand.cs
+++ b/backend/MASZ/Commands/UnbanCommand.cs
@@ -108,7 +108,7 @@ namespace MASZ.Commands
 
             var embed = castInteraction.Message.Embeds.FirstOrDefault().ToEmbedBuilder()
                 .WithColor(new Color(Convert.ToUInt32(int.Parse("7289da", NumberStyles.HexNumber))));  // discord blurple
-            
+
             embed.Fields = new()
             {
                 new EmbedFieldBuilder().WithName(Translator.T().CmdUndoResultTitle()).WithValue(Translator.T().CmdUndoUnbanButtonsDelete())

--- a/backend/MASZ/Commands/UnmuteCommand.cs
+++ b/backend/MASZ/Commands/UnmuteCommand.cs
@@ -110,7 +110,7 @@ namespace MASZ.Commands
 
             var embed = castInteraction.Message.Embeds.FirstOrDefault().ToEmbedBuilder()
                 .WithColor(new Color(Convert.ToUInt32(int.Parse("7289da", NumberStyles.HexNumber))));  // discord blurple
-            
+
             embed.Fields = new()
             {
                 new EmbedFieldBuilder().WithName(Translator.T().CmdUndoResultTitle()).WithValue(Translator.T().CmdUndoUnmuteResultDeleted())

--- a/backend/MASZ/Controllers/api/v1/AppSettingsController.cs
+++ b/backend/MASZ/Controllers/api/v1/AppSettingsController.cs
@@ -1,7 +1,4 @@
-using Discord;
 using MASZ.Dtos.AppSettings;
-using MASZ.Dtos.GuildMotd;
-using MASZ.Enums;
 using MASZ.Models;
 using MASZ.Repositories;
 using Microsoft.AspNetCore.Authorization;

--- a/backend/MASZ/Controllers/api/v1/AppealController.cs
+++ b/backend/MASZ/Controllers/api/v1/AppealController.cs
@@ -1,13 +1,12 @@
-using MASZ.Models;
+using Discord;
+using MASZ.Dtos.Appeal;
 using MASZ.Enums;
+using MASZ.Models;
 using MASZ.Models.Views;
 using MASZ.Repositories;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
-using MASZ.Dtos.Appeal;
-using MASZ.Exceptions;
+using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
-using Discord;
 
 namespace MASZ.Controllers
 {
@@ -167,7 +166,7 @@ namespace MASZ.Controllers
             }
 
             AppealRepository repo = AppealRepository.CreateDefault(_serviceProvider);
-            if (! await repo.UserIsAllowedToCreateNewAppeal(guildId, currentUser.Id))
+            if (!await repo.UserIsAllowedToCreateNewAppeal(guildId, currentUser.Id))
             {
                 return BadRequest();
             }

--- a/backend/MASZ/Controllers/api/v1/AppealStructureController.cs
+++ b/backend/MASZ/Controllers/api/v1/AppealStructureController.cs
@@ -1,11 +1,10 @@
-using MASZ.Models;
+using MASZ.Dtos.Appeal;
 using MASZ.Enums;
+using MASZ.Models;
 using MASZ.Models.Views;
 using MASZ.Repositories;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
-using MASZ.Dtos.Appeal;
-using MASZ.Exceptions;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MASZ.Controllers
 {

--- a/backend/MASZ/Controllers/api/v1/AutoModerationEventController.cs
+++ b/backend/MASZ/Controllers/api/v1/AutoModerationEventController.cs
@@ -58,7 +58,7 @@ namespace MASZ.Controllers
 
             return Ok(new
             {
-                events = events.Skip(startPage*20).Take(20).Select(x => new AutoModerationEventView(x)),
+                events = events.Skip(startPage * 20).Take(20).Select(x => new AutoModerationEventView(x)),
                 count = events.Count()
             });
         }

--- a/backend/MASZ/Controllers/api/v1/EmbedController.cs
+++ b/backend/MASZ/Controllers/api/v1/EmbedController.cs
@@ -1,9 +1,9 @@
-using MASZ.Enums;
-using MASZ.Models;
-using Microsoft.AspNetCore.Mvc;
-using MASZ.Exceptions;
-using MASZ.Repositories;
 using Discord;
+using MASZ.Enums;
+using MASZ.Exceptions;
+using MASZ.Models;
+using MASZ.Repositories;
+using Microsoft.AspNetCore.Mvc;
 using System.Text.RegularExpressions;
 
 namespace MASZ.Controllers
@@ -21,7 +21,7 @@ namespace MASZ.Controllers
         [HttpGet]
         public async Task<IActionResult> GetOEmbedInfo([FromQuery] string url = "")
         {
-            if (! string.IsNullOrEmpty(url))
+            if (!string.IsNullOrEmpty(url))
             {
                 Match modCaseMatch = _modCaseRegex.Match(url);
                 if (modCaseMatch.Success)

--- a/backend/MASZ/Controllers/api/v1/GuildConfigController.cs
+++ b/backend/MASZ/Controllers/api/v1/GuildConfigController.cs
@@ -1,11 +1,9 @@
-using Discord;
 using MASZ.Dtos.GuildConfig;
 using MASZ.Enums;
 using MASZ.Exceptions;
 using MASZ.Models;
 using MASZ.Models.Views;
 using MASZ.Repositories;
-using MASZ.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/backend/MASZ/Controllers/api/v1/MetaController.cs
+++ b/backend/MASZ/Controllers/api/v1/MetaController.cs
@@ -1,10 +1,7 @@
+using MASZ.Dtos;
 using MASZ.Models.Views;
-using MASZ.Models;
 using Microsoft.AspNetCore.Mvc;
 using RestSharp;
-using MASZ.Repositories;
-using Discord;
-using MASZ.Dtos;
 
 namespace MASZ.Controllers
 {

--- a/backend/MASZ/Controllers/api/v1/ModCaseMappingController.cs
+++ b/backend/MASZ/Controllers/api/v1/ModCaseMappingController.cs
@@ -1,5 +1,4 @@
 using MASZ.Enums;
-using MASZ.Models;
 using MASZ.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/MASZ/Controllers/api/v1/ScheduledMessageController.cs
+++ b/backend/MASZ/Controllers/api/v1/ScheduledMessageController.cs
@@ -1,5 +1,4 @@
 ﻿using MASZ.Dtos;
-using MASZ.Dtos.UserNote;
 using MASZ.Enums;
 using MASZ.Exceptions;
 using MASZ.Models;
@@ -38,7 +37,8 @@ namespace MASZ.Controllers
                                                      _discordAPI.FetchGuildChannels(guildId, CacheBehavior.OnlyCache).FirstOrDefault(x => x.Id == message.ChannelId)));
             }
 
-            return Ok(new {
+            return Ok(new
+            {
                 items = results,
                 fullSize
             });

--- a/backend/MASZ/Controllers/api/v1/Views/CaseViewController.cs
+++ b/backend/MASZ/Controllers/api/v1/Views/CaseViewController.cs
@@ -72,9 +72,10 @@ namespace MASZ.Controllers
             }
 
             bool isMod = await identity.HasPermissionOnGuild(DiscordPermission.Moderator, guildId);
-            if (isMod) {
+            if (isMod)
+            {
                 caseView.LinkedCases = modCase.MappingsA.Select(mapping => new CaseView(mapping.CaseB)).ToList();
-                caseView.LinkedCases.AddRange(modCase.MappingsB.Select(mapping =>new CaseView(mapping.CaseA)));
+                caseView.LinkedCases.AddRange(modCase.MappingsB.Select(mapping => new CaseView(mapping.CaseA)));
             }
 
             if (!(isMod || guildConfig.PublishModeratorInfo))

--- a/backend/MASZ/Controllers/api/v1/Views/UserMappingViewController.cs
+++ b/backend/MASZ/Controllers/api/v1/Views/UserMappingViewController.cs
@@ -1,9 +1,9 @@
-using System.ComponentModel.DataAnnotations;
 using MASZ.Enums;
 using MASZ.Models;
 using MASZ.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 
 namespace MASZ.Controllers
 {

--- a/backend/MASZ/Controllers/api/v1/Views/UserNoteViewController.cs
+++ b/backend/MASZ/Controllers/api/v1/Views/UserNoteViewController.cs
@@ -1,9 +1,9 @@
-using System.ComponentModel.DataAnnotations;
 using MASZ.Enums;
 using MASZ.Models;
 using MASZ.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 
 namespace MASZ.Controllers
 {

--- a/backend/MASZ/Dtos/Appeal/AppealDto.cs
+++ b/backend/MASZ/Dtos/Appeal/AppealDto.cs
@@ -1,6 +1,3 @@
-using MASZ.Enums;
-using System.ComponentModel.DataAnnotations;
-
 namespace MASZ.Dtos.Appeal
 {
     public class AppealDto

--- a/backend/MASZ/Dtos/Appeal/AppealStructureDto.cs
+++ b/backend/MASZ/Dtos/Appeal/AppealStructureDto.cs
@@ -1,4 +1,3 @@
-using MASZ.Enums;
 using System.ComponentModel.DataAnnotations;
 
 namespace MASZ.Dtos.Appeal

--- a/backend/MASZ/Dtos/Appeal/AppealStructureOrderDto.cs
+++ b/backend/MASZ/Dtos/Appeal/AppealStructureOrderDto.cs
@@ -1,4 +1,3 @@
-using MASZ.Enums;
 using System.ComponentModel.DataAnnotations;
 
 namespace MASZ.Dtos.Appeal

--- a/backend/MASZ/Exceptions/EmbedCreator.cs
+++ b/backend/MASZ/Exceptions/EmbedCreator.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace MASZ.Services
 {
-	public static class EmbedCreator
+    public static class EmbedCreator
     {
         private readonly static string CHECK = "\u2705";
         private readonly static string X_CHECK = "\u274C";

--- a/backend/MASZ/MASZ.csproj
+++ b/backend/MASZ/MASZ.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
     <PackageReference Include="RestSharp" Version="107.0.0-preview.12" />
-    <PackageReference Include="Scrutor" Version="3.3.0" />
+    <PackageReference Include="Scrutor" Version="4.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
   </ItemGroup>
 </Project>

--- a/backend/MASZ/Migrations/20220121180713_AddScheduledMessage.cs
+++ b/backend/MASZ/Migrations/20220121180713_AddScheduledMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Metadata;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/backend/MASZ/Migrations/20220220164524_AddBanAppeal.cs
+++ b/backend/MASZ/Migrations/20220220164524_AddBanAppeal.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Metadata;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/backend/MASZ/Models/Database/AppSettings.cs
+++ b/backend/MASZ/Models/Database/AppSettings.cs
@@ -21,7 +21,7 @@ namespace MASZ.Models
                         "<meta property=\"og:site_name\" content=\"MASZ by zaanposni\" />" +
                         "<meta property=\"og:title\" content=\"" + EmbedTitle + "\" />" +
                         "<meta property=\"og:url\" content=\"" + url + "\" />" +
-                        (EmbedShowIcon && ! string.IsNullOrWhiteSpace(iconUrl) ? "<meta property=\"og:image\" content=\"" + iconUrl + "\" />" : "") +
+                        (EmbedShowIcon && !string.IsNullOrWhiteSpace(iconUrl) ? "<meta property=\"og:image\" content=\"" + iconUrl + "\" />" : "") +
                         (string.IsNullOrWhiteSpace(EmbedContent) ? "" : "<meta property=\"og:description\" content=\"" + EmbedContent + "\" />") +
                     "</head>" +
                 "</html>";

--- a/backend/MASZ/Models/Database/Appeal.cs
+++ b/backend/MASZ/Models/Database/Appeal.cs
@@ -1,5 +1,5 @@
-using System.ComponentModel.DataAnnotations;
 using MASZ.Enums;
+using System.ComponentModel.DataAnnotations;
 
 namespace MASZ.Models
 {

--- a/backend/MASZ/Models/Database/ModCase.cs
+++ b/backend/MASZ/Models/Database/ModCase.cs
@@ -1,8 +1,8 @@
+using Discord;
 using MASZ.Enums;
+using MASZ.Extensions;
 using MASZ.Services;
 using System.ComponentModel.DataAnnotations;
-using Discord;
-using MASZ.Extensions;
 
 namespace MASZ.Models
 {
@@ -87,7 +87,7 @@ namespace MASZ.Models
                         $"<meta property=\"og:title\" content=\"#{this.CaseId}: {this.Title}\" />" +
                         $"<meta property=\"og:url\" content=\"{baseUrl}/guilds/{this.GuildId}/cases/{this.CaseId}\" />" +
                         $"<meta property=\"og:description\" content=\"{this.GetPunishment(translator)}: {this.Description}\" />" +
-                        ( user != null ? $"<meta property=\"og:image\" content=\"{user.GetAvatarOrDefaultUrl()}\" />" : "") +
+                        (user != null ? $"<meta property=\"og:image\" content=\"{user.GetAvatarOrDefaultUrl()}\" />" : "") +
                     "</head>" +
                 "</html>";
         }

--- a/backend/MASZ/Models/GuildFeatureTest.cs
+++ b/backend/MASZ/Models/GuildFeatureTest.cs
@@ -1,5 +1,4 @@
 using Discord;
-using MASZ.Enums;
 
 namespace MASZ.Models
 {

--- a/backend/MASZ/Models/Views/CaseCount.cs
+++ b/backend/MASZ/Models/Views/CaseCount.cs
@@ -1,5 +1,3 @@
-using MASZ.Enums;
-
 namespace MASZ.Models
 {
     public class CaseCount

--- a/backend/MASZ/Program.cs
+++ b/backend/MASZ/Program.cs
@@ -8,7 +8,6 @@ using MASZ.Middlewares;
 using MASZ.Plugins;
 using MASZ.Repositories;
 using MASZ.Services;
-using MASZ.Utils;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -25,13 +24,14 @@ builder.Logging.AddProvider(new LoggerProvider());
 builder.WebHost.UseUrls("http://0.0.0.0:80/");
 
 string connectionString =
-            $"Server={   Environment.GetEnvironmentVariable("MYSQL_HOST")};" +
-            $"Port={     Environment.GetEnvironmentVariable("MYSQL_PORT")};" +
-            $"Database={ Environment.GetEnvironmentVariable("MYSQL_DATABASE")};" +
-            $"Uid={      Environment.GetEnvironmentVariable("MYSQL_USER")};" +
-            $"Pwd={      Environment.GetEnvironmentVariable("MYSQL_PASSWORD")};";
+            $"Server={Environment.GetEnvironmentVariable("MYSQL_HOST")};" +
+            $"Port={Environment.GetEnvironmentVariable("MYSQL_PORT")};" +
+            $"Database={Environment.GetEnvironmentVariable("MYSQL_DATABASE")};" +
+            $"Uid={Environment.GetEnvironmentVariable("MYSQL_USER")};" +
+            $"Pwd={Environment.GetEnvironmentVariable("MYSQL_PASSWORD")};";
 
-if (false) {
+if (false)
+{
     connectionString =
             $"Server=localhost;" +
             $"Port=3306;" +

--- a/backend/MASZ/Repositories/AppSettingsRepository.cs
+++ b/backend/MASZ/Repositories/AppSettingsRepository.cs
@@ -1,7 +1,3 @@
-using Discord;
-using MASZ.Enums;
-using MASZ.Exceptions;
-using MASZ.Extensions;
 using MASZ.Models;
 
 namespace MASZ.Repositories

--- a/backend/MASZ/Repositories/AppealAnswerRepository.cs
+++ b/backend/MASZ/Repositories/AppealAnswerRepository.cs
@@ -1,7 +1,3 @@
-using Discord;
-using MASZ.Enums;
-using MASZ.Exceptions;
-using MASZ.Extensions;
 using MASZ.Models;
 
 namespace MASZ.Repositories

--- a/backend/MASZ/Repositories/AppealStructureRepository.cs
+++ b/backend/MASZ/Repositories/AppealStructureRepository.cs
@@ -1,7 +1,4 @@
-using Discord;
-using MASZ.Enums;
 using MASZ.Exceptions;
-using MASZ.Extensions;
 using MASZ.Models;
 
 namespace MASZ.Repositories

--- a/backend/MASZ/Repositories/FileRepository.cs
+++ b/backend/MASZ/Repositories/FileRepository.cs
@@ -6,7 +6,7 @@ using MASZ.Models;
 namespace MASZ.Repositories
 {
 
-	public class FileRepository : BaseRepository<FileRepository>
+    public class FileRepository : BaseRepository<FileRepository>
     {
         private readonly Identity _identity;
         private FileRepository(IServiceProvider serviceProvider, Identity identity) : base(serviceProvider)

--- a/backend/MASZ/Services/DiscordAPIInterface.cs
+++ b/backend/MASZ/Services/DiscordAPIInterface.cs
@@ -455,10 +455,10 @@ namespace MASZ.Services
                 if (member == null) return false;
 
                 RequestOptions options = new();
-                if (! string.IsNullOrEmpty(reason))
+                if (!string.IsNullOrEmpty(reason))
                     options.AuditLogReason = reason;
 
-                await member.SetTimeOutAsync(until - DateTime.UtcNow ,options);
+                await member.SetTimeOutAsync(until - DateTime.UtcNow, options);
             }
             catch (Exception e)
             {
@@ -478,7 +478,7 @@ namespace MASZ.Services
                 if (member == null) return false;
 
                 RequestOptions options = new();
-                if (! string.IsNullOrEmpty(reason))
+                if (!string.IsNullOrEmpty(reason))
                     options.AuditLogReason = reason;
 
                 await member.RemoveTimeOutAsync(options);
@@ -503,7 +503,7 @@ namespace MASZ.Services
                 if (role == null) return false;
 
                 RequestOptions options = new();
-                if (! string.IsNullOrEmpty(reason))
+                if (!string.IsNullOrEmpty(reason))
                     options.AuditLogReason = reason;
 
                 await member.AddRoleAsync(role, options);

--- a/backend/MASZ/Services/DiscordAnnouncer.cs
+++ b/backend/MASZ/Services/DiscordAnnouncer.cs
@@ -7,7 +7,7 @@ using MASZ.Utils;
 
 namespace MASZ.Services
 {
-	public class DiscordAnnouncer : IEvent
+    public class DiscordAnnouncer : IEvent
     {
         private readonly ILogger<DiscordAnnouncer> _logger;
         private readonly InternalConfiguration _config;

--- a/backend/MASZ/Services/Scheduler.cs
+++ b/backend/MASZ/Services/Scheduler.cs
@@ -117,7 +117,8 @@ namespace MASZ.Services
                     guild = _discordAPI.FetchGuildInfo(message.GuildId, CacheBehavior.OnlyCache);
                     if (guild == null)
                         throw new Exception();
-                } catch (Exception)
+                }
+                catch (Exception)
                 {
                     _logger.LogInformation($"Failed scheduled message {message.Id}. Reason unknown.");
                     await repo.SetMessageAsFailed(message.Id, ScheduledMessageFailureReason.Unknown);

--- a/backend/MASZ/Utils/IEvent.cs
+++ b/backend/MASZ/Utils/IEvent.cs
@@ -1,9 +1,9 @@
 ﻿namespace MASZ.Utils
 {
-	public interface IEvent
-	{
+    public interface IEvent
+    {
 
-		public void RegisterEvents();
+        public void RegisterEvents();
 
-	}
+    }
 }

--- a/backend/MASZ/Utils/Translation.cs
+++ b/backend/MASZ/Utils/Translation.cs
@@ -1,6 +1,6 @@
 using Discord;
-using MASZ.Extensions;
 using MASZ.Enums;
+using MASZ.Extensions;
 using MASZ.Models;
 
 namespace MASZ.Utils
@@ -529,7 +529,7 @@ namespace MASZ.Utils
             {
                 Language.de => $"Ein **Vorfall** für <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) wurde von <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}) aktualisiert.",
                 Language.at => $"A **Vorfoi** fia <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) is fo <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}) aktualisiert woan.",
-                Language.fr => $"Un **Modcase** pour <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) a été mis à jour par <@{moderator.Id}> ({moderator.Username}#{moderator. Discriminator}).",
+                Language.fr => $"Un **Modcase** pour <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) a été mis à jour par <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.es => $"Un **Modcase** para <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) ha sido actualizado por <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.ru => $"**Modcase** для <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) был обновлен <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.it => $"Un **Modcase** per <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) è stato aggiornato da <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
@@ -555,7 +555,7 @@ namespace MASZ.Utils
             {
                 Language.de => $"Ein **Vorfall** für <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) wurde von <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}) gelöscht.",
                 Language.at => $"A **Vorfoi** fia <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) is vo <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}) glescht woan.",
-                Language.fr => $"Un **Modcase** pour <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) a été supprimé par <@{moderator.Id}> ({moderator.Username}#{moderator. Discriminator}).",
+                Language.fr => $"Un **Modcase** pour <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) a été supprimé par <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.es => $"Un **Modcase** para <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) ha sido eliminado por <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.ru => $"**Modcase** для <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) был удален <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
                 Language.it => $"Un **Modcase** per <@{modCase.UserId}> ({modCase.Username}#{modCase.Discriminator}) è stato eliminato da <@{moderator.Id}> ({moderator.Username}#{moderator.Discriminator}).",
@@ -699,8 +699,8 @@ namespace MASZ.Utils
                 Language.de => $"Die Moderatoren von `{guild.Name}` haben dich temporär stummgeschalten bis {modCase.PunishedUntil.Value.ToDiscordTS()}.\nFür weitere Informationen besuche: {serviceBaseUrl}",
                 Language.at => $"Die Moderatoan vo `{guild.Name}` hom di bis am {modCase.PunishedUntil.Value.ToDiscordTS()} stummgschoit.\nFia weitere Infos schau bei {serviceBaseUrl} noch",
                 Language.fr => $"Les modérateurs de la guilde `{guild.Name}` vous ont temporairement mis en sourdine jusqu'à {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPour plus d'informations ou pour une réhabilitation, visitez : {serviceBaseUrl}",
-                Language.es => $"Los moderadores del gremio `{guild.Name}` te han silenciado temporalmente hasta {modCase.PunishedUntil.Value.ToDiscordTS ()}.\nPara obtener más información o rehabilitación, visite: {serviceBaseUrl}",
-                Language.ru => $"Модераторы гильдии `{guild.Name}` временно отключили ваш звук до {modCase.PunishedUntil.Value.ToDiscordTS ()}.\nДля получения дополнительной информации или реабилитации посетите: {serviceBaseUrl}",
+                Language.es => $"Los moderadores del gremio `{guild.Name}` te han silenciado temporalmente hasta {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPara obtener más información o rehabilitación, visite: {serviceBaseUrl}",
+                Language.ru => $"Модераторы гильдии `{guild.Name}` временно отключили ваш звук до {modCase.PunishedUntil.Value.ToDiscordTS()}.\nДля получения дополнительной информации или реабилитации посетите: {serviceBaseUrl}",
                 Language.it => $"I moderatori della gilda `{guild.Name}` ti hanno temporaneamente disattivato l'audio fino a {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPer maggiori informazioni o visita riabilitativa: {serviceBaseUrl}",
                 _ => $"The moderators of guild `{guild.Name}` have temporarily muted you until {modCase.PunishedUntil.Value.ToDiscordTS()}.\nFor more information or rehabilitation visit: {serviceBaseUrl}",
             };
@@ -725,8 +725,8 @@ namespace MASZ.Utils
                 Language.de => $"Die Moderatoren von `{guild.Name}` haben dich temporär gebannt bis {modCase.PunishedUntil.Value.ToDiscordTS()}.\nFür weitere Informationen besuche: {serviceBaseUrl}",
                 Language.at => $"Die Moderatoan vo `{guild.Name}` hom di bis am {modCase.PunishedUntil.Value.ToDiscordTS()} vom Serva ausgsperrt.\nFia weitere Infos schau bei {serviceBaseUrl} noch.",
                 Language.fr => $"Les modérateurs de la guilde `{guild.Name}` vous ont temporairement banni jusqu'à {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPour plus d'informations ou pour une réhabilitation, visitez : {serviceBaseUrl}",
-                Language.es => $"Los moderadores del gremio `{guild.Name}` te han baneado temporalmente hasta el {modCase.PunishedUntil.Value.ToDiscordTS ()}.\nPara obtener más información o rehabilitación, visite: {serviceBaseUrl}",
-                Language.ru => $"Модераторы гильдии `{guild.Name}` временно заблокировали вас до {modCase.PunishedUntil.Value.ToDiscordTS ()}.\nДля получения дополнительной информации или реабилитации посетите: {serviceBaseUrl}",
+                Language.es => $"Los moderadores del gremio `{guild.Name}` te han baneado temporalmente hasta el {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPara obtener más información o rehabilitación, visite: {serviceBaseUrl}",
+                Language.ru => $"Модераторы гильдии `{guild.Name}` временно заблокировали вас до {modCase.PunishedUntil.Value.ToDiscordTS()}.\nДля получения дополнительной информации или реабилитации посетите: {serviceBaseUrl}",
                 Language.it => $"I moderatori della gilda `{guild.Name}` ti hanno temporaneamente bannato fino al {modCase.PunishedUntil.Value.ToDiscordTS()}.\nPer maggiori informazioni o visita riabilitativa: {serviceBaseUrl}",
                 _ => $"The moderators of guild `{guild.Name}` have temporarily banned you until {modCase.PunishedUntil.Value.ToDiscordTS()}.\nFor more information or rehabilitation visit: {serviceBaseUrl}",
             };
@@ -1180,8 +1180,8 @@ namespace MASZ.Utils
                 Language.de => $"{user.Mention} (registriert {registered.ToDiscordTS()}) ist mit dem Invite `{invite}` beigetreten.",
                 Language.at => $"{user.Mention} (registriat {registered.ToDiscordTS()}) is mit da Eiladung `{invite}` beigetretn.",
                 Language.fr => $"{user.Mention} (enregistré {registered.ToDiscordTS()}) rejoint avec l'invitation `{invite}`.",
-                Language.es => $"{user.Mention} (registrado {registered.ToDiscordTS ()}) se unió con la invitación `{invite}`.",
-                Language.ru => $"{user.Mention} (зарегистрированный {registered.ToDiscordTS ()}) присоединился с приглашением `{invite}`.",
+                Language.es => $"{user.Mention} (registrado {registered.ToDiscordTS()}) se unió con la invitación `{invite}`.",
+                Language.ru => $"{user.Mention} (зарегистрированный {registered.ToDiscordTS()}) присоединился с приглашением `{invite}`.",
                 Language.it => $"{user.Mention} (registrato {registered.ToDiscordTS()}) si è unito con l'invito `{invite}`.",
                 _ => $"{user.Mention} (registered {registered.ToDiscordTS()}) joined with invite `{invite}`.",
             };
@@ -1934,8 +1934,8 @@ namespace MASZ.Utils
                 Language.de => $"`{inviteCode}` erstellt am {createdAt.ToDiscordTS()}.",
                 Language.at => $"`{inviteCode}` erstöt vo {createdAt.ToDiscordTS()}.",
                 Language.fr => $"`{inviteCode}` créé à {createdAt.ToDiscordTS()}.",
-                Language.es => $"`{inviteCode}` creado en {createdAt.ToDiscordTS ()}.",
-                Language.ru => $"`{inviteCode}` создан в {createdAt.ToDiscordTS ()}.",
+                Language.es => $"`{inviteCode}` creado en {createdAt.ToDiscordTS()}.",
+                Language.ru => $"`{inviteCode}` создан в {createdAt.ToDiscordTS()}.",
                 Language.it => $"`{inviteCode}` creato su {createdAt.ToDiscordTS()}.",
                 _ => $"`{inviteCode}` created at {createdAt.ToDiscordTS()}.",
             };
@@ -1960,8 +1960,8 @@ namespace MASZ.Utils
                 Language.de => $"`{inviteCode}` erstellt von {createdBy.Mention} am {createdAt.ToDiscordTS()}.",
                 Language.at => $"`{inviteCode}` erstöt vo {createdBy.Mention} om {createdAt.ToDiscordTS()}.",
                 Language.fr => $"`{inviteCode}` créé par {createdBy.Mention} à {createdAt.ToDiscordTS()}.",
-                Language.es => $"`{inviteCode}` creado por {createdBy.Mention} en {createdAt.ToDiscordTS ()}.",
-                Language.ru => $"`{inviteCode}` создан {createdBy.Mention} в {createdAt.ToDiscordTS ()}.",
+                Language.es => $"`{inviteCode}` creado por {createdBy.Mention} en {createdAt.ToDiscordTS()}.",
+                Language.ru => $"`{inviteCode}` создан {createdBy.Mention} в {createdAt.ToDiscordTS()}.",
                 Language.it => $"`{inviteCode}` creato da {createdBy.Mention} su {createdAt.ToDiscordTS()}.",
                 _ => $"`{inviteCode}` created by {createdBy.Mention} at {createdAt.ToDiscordTS()}.",
             };


### PR DESCRIPTION
Bumped Scrutor from 3.3.0 to 4.2.0

# Scrutor 4.2.0
- [Release Notes](https://github.com/khellang/Scrutor/releases/tag/v4.2.0)
- [Download and Install](https://www.nuget.org/packages/Scrutor/4.2.0)

# Scrutor 3.3.0
- [Release Notes](https://github.com/khellang/Scrutor/releases/tag/v3.3.0)
- [Download and Install](https://www.nuget.org/packages/Scrutor/3.3.0)