### PR TITLE
fix: 559 discord resources whitelisted in automod

### DIFF
--- a/backend/MASZ/AutoModeration/InviteCheck.cs
+++ b/backend/MASZ/AutoModeration/InviteCheck.cs
@@ -7,6 +7,8 @@ namespace MASZ.AutoModeration
     public static class InviteChecker
     {
         private static readonly Regex _inviteRegex = new(@"(https?:\/\/)?(www\.)?(discord(app)?\.(gg|io|me|li|com)(\/invite)?)\/(?![a-z]+\/)([^\?\s]+)(\?event=([^\s]+))?");
+        //private static readonly Regex _discordResourcesWhitelist = new(@"(https?:\/\/)?(www\.)?(discord(app)?\.com\/(download|nitro|company|careers|branding|newsroom|college|safetycenter|blog|build|streamkit|creators|terms|privacy|guidelines|acknowledgements|licenses|moderation))\/?");
+        private static readonly Regex _discordResourcesWhitelist = new(@"(https?:\/\/)?(www\.)?(discord(app)?\.com\/)(?:(?!invite))");
         public static async Task<bool> Check(IMessage message, AutoModerationConfig config, IDiscordClient client)
         {
             if (string.IsNullOrEmpty(message.Content))
@@ -29,6 +31,10 @@ namespace MASZ.AutoModeration
                 {
                     try
                     {
+                        if (_discordResourcesWhitelist.Match(usedInvite.Value).Success)
+                        {
+                            continue;
+                        }
                         string inviteCode = usedInvite.Groups.Values.Skip(7).First().ToString().Trim();
                         if (alreadyChecked.Contains(inviteCode))
                         {


### PR DESCRIPTION
#559 

I added a regex matching all discord.com links not containing "/invite". All matches from `_inviteRegex` are compared against the whitelist, and if a match is made the link is skipped.

The commented out regex works as well and is much more restrictive, therefore it could be safer, but also it is way too long.  Although if it ends up being a better solution it's ready to be uncommented. 

The 2 deleted messages in the screenshot below were invite links (both discord.gg and discord.com/invite)
![image](https://user-images.githubusercontent.com/79521176/207734030-86d259f4-2d83-4bdb-8023-d8cf0fa09c55.png)
