### PR TITLE
Fix: wrong regex and time to punished-time issues

### DIFF
--- a/nginx/masz-svelte/src/components/guilds/cases/EditCase.svelte
+++ b/nginx/masz-svelte/src/components/guilds/cases/EditCase.svelte
@@ -239,7 +239,7 @@
                     <TimePicker
                         class="!grow-0"
                         bind:value={inputPunishedUntilTime}
-                        invalid={!!inputPunishedUntilTime && !/([01][012]|[1-9]):[0-5][0-9](\\s)?/.test(inputPunishedUntilTime)}
+                        invalid={!!inputPunishedUntilTime && !/^([01]\d|2[0-3]):[0-5]\d$/.test(inputPunishedUntilTime)}
                         invalidText={$_("guilds.casedialog.formatisrequired", { values: { format: $currentLanguage?.timeFormat ?? "hh:MM" } })}
                         labelText={$_("guilds.casedialog.punisheduntil")}
                         placeholder={$currentLanguage?.timeFormat ?? "hh:MM"} />

--- a/nginx/masz-svelte/src/components/guilds/cases/EditCase.svelte
+++ b/nginx/masz-svelte/src/components/guilds/cases/EditCase.svelte
@@ -104,13 +104,32 @@
     }
 
     $: calculatePunishedUntil(inputPunishedUntilDate, inputPunishedUntilTime, $currentLanguage);
-    function calculatePunishedUntil(date: string, time: string, language?: ILanguageSelect) {
-        if (language) {
-            date
-                ? (modCase.punishedUntil = moment(`${date} ${time ? time : "00:00"}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
-                      .utc(false)
-                      .utcOffset(utcOffset))
-                : (modCase.punishedUntil = null);
+    function calculatePunishedUntil(date: string, time?: string, language?: ILanguageSelect) {
+        if(language) {
+
+            let newTime:string;
+            time ? newTime=time : newTime="12:00";
+
+            if(date) {
+                
+                modCase.punishedUntil = moment(`${date} ${newTime}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
+                    .utc(false)
+                    .utcOffset(utcOffset)
+            }
+            else {
+
+                //Getting current time and setting the new moment to be 12 hours in the future
+                const currentDate = new Date();
+                const inputDate = `${currentDate.getFullYear()}-${currentDate.getMonth()+1}-${currentDate.getDate()}`;
+                const inputClock = `${currentDate.getHours()}:${currentDate.getMinutes()}`;
+
+                const newMoment = moment(`${inputDate} ${inputClock}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
+                .utc(false)
+                .utcOffset(utcOffset)
+                .add(12, 'hours');
+
+                modCase.punishedUntil = newMoment;
+            }
         }
     }
 

--- a/nginx/masz-svelte/src/components/guilds/cases/NewCase.svelte
+++ b/nginx/masz-svelte/src/components/guilds/cases/NewCase.svelte
@@ -587,7 +587,7 @@
                     <TimePicker
                         class="!grow-0"
                         bind:value={inputPunishedUntilTime}
-                        invalid={!!inputPunishedUntilTime && !/([01][012]|[1-9]):[0-5][0-9](\\s)?/.test(inputPunishedUntilTime)}
+                        invalid={!!inputPunishedUntilTime && !/^([01]\d|2[0-3]):[0-5]\d$/.test(inputPunishedUntilTime)}
                         invalidText={$_("guilds.casedialog.formatisrequired", { values: { format: $currentLanguage?.timeFormat ?? "hh:MM"} })}
                         labelText={$_("guilds.casedialog.punisheduntil")}
                         placeholder={$currentLanguage?.timeFormat ?? "hh:MM"} />

--- a/nginx/masz-svelte/src/components/guilds/cases/NewCase.svelte
+++ b/nginx/masz-svelte/src/components/guilds/cases/NewCase.svelte
@@ -202,14 +202,34 @@
     }
 
     $: calculatePunishedUntil(inputPunishedUntilDate, inputPunishedUntilTime, $currentLanguage);
-    function calculatePunishedUntil(date: string, time: string, language?: ILanguageSelect) {
-        if (language) {
-            date
-                ? (modCase.punishedUntil = moment(`${date} ${time ? time : "00:00"}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
+    function calculatePunishedUntil(date: string, time?: string, language?: ILanguageSelect) {
+        if(language) {
+
+            let newTime:string;
+            time ? newTime=time : newTime="12:00";
+            
+            if(date) {
+                
+                modCase.punishedUntil = moment(`${date} ${newTime}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
                       .utc(false)
-                      .utcOffset(utfOffset))
-                : (modCase.punishedUntil = null);
+                      .utcOffset(utfOffset)
+            }
+            else {
+
+                //Getting current time and setting the new moment to be 12 hours in the future
+                const currentDate = new Date();
+                const inputDate = `${currentDate.getFullYear()}-${currentDate.getMonth()+1}-${currentDate.getDate()}`;
+                const inputClock = `${currentDate.getHours()}:${currentDate.getMinutes()}`;
+
+                const newMoment = moment(`${inputDate} ${inputClock}`, `${language.momentDateFormat} ${language.momentTimeFormat}`)
+                .utc(false)
+                .utcOffset(utfOffset)
+                .add(12, 'hours');
+
+                modCase.punishedUntil = newMoment;
+            }
         }
+
     }
 
     function onSubmit() {


### PR DESCRIPTION
### Fixes #579

- [x] Correct the regex
- [x] Correct issues with time set to null

Affected files: 

- EditCase.svelte
- NewCase.svelte

**Regex-issue**
Original regex: `/([01][012]|[1-9]):[0-5][0-9](\\s)?/`
New regex: `/^([01]\d|2[0-3]):[0-5]\d$/`


**Time issue**
I have made changes to the _calculatePunishedUntil_ function.
What I have done:

1. Made the time parameter optional
2. If the `time` is false, the time is being set to 12 hours by default
3. If `date` is false, the `modCase.punishedUntil` is being set to 12 hours in the future

Errors I have observed, but not fixed:

1. I presume that the variable `utfOffset` in _NewCase.svelte_ should be `utcOffset`


